### PR TITLE
Fix: GameManager 수정, StageScene에서 120FPS 지원

### DIFF
--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Global/GameManager.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Global/GameManager.cs
@@ -8,11 +8,12 @@ public class GameManager : MonoBehaviour
     [Header("# Game Control")] public float gameTime;
 
     [Header("# Player Info")] public int collectedCatBox;
-
+    
     private void Awake()
     {
         Instance = this;
         _mapManager = FindObjectOfType<MapManager>();
+        Application.targetFrameRate = 120;
     }
 
     void Update()

--- a/ProjectDaNyan/ProjectSettings/ProjectSettings.asset
+++ b/ProjectDaNyan/ProjectSettings/ProjectSettings.asset
@@ -240,7 +240,7 @@ PlayerSettings:
   appleEnableAutomaticSigning: 0
   iOSRequireARKit: 0
   iOSAutomaticallyDetectAndAddCapabilities: 1
-  appleEnableProMotion: 0
+  appleEnableProMotion: 1
   shaderPrecisionModel: 0
   clonedFromGUID: c0afd0d1d80e3634a9dac47e8a0426ea
   templatePackageId: com.unity.template.3d@8.1.1

--- a/ProjectDaNyan/ProjectSettings/QualitySettings.asset
+++ b/ProjectDaNyan/ProjectSettings/QualitySettings.asset
@@ -273,7 +273,7 @@ QualitySettings:
     realtimeReflectionProbes: 1
     billboardsFaceCameraPosition: 1
     useLegacyDetailDistribution: 1
-    vSyncCount: 1
+    vSyncCount: 0
     realtimeGICPUUsage: 100
     lodBias: 2
     maximumLODLevel: 0


### PR DESCRIPTION
작업내용:

Apple ProMotion 기술 사용하도록 프로젝트 세팅 변경
> 120Hz 디스플레이가 탑재된 디바이스 (13 이후 아이폰 프로 라인업, 1세대를 제외한 아이패드 프로 라인업)
에서 부하가 적으면 최대 120FPS까지 프레임이 올라감

> ProMotion 디스플레이가 없는 디바이스는 프레임이 60에서 자동으로 리미트 걸림
(하드웨어적 한계로 인해 120FPS로 렌더링을 해도 디스플레이가 받지 못함 > 시스템에서 자동으로 컷하는듯)

GameManager 파일 수정
> 최대 프레임레이트 120으로 설정