### PR TITLE
Fix: Missing Materials 표시 수정

### DIFF
--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteLongRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteLongRangePrefab.prefab
@@ -9,9 +9,9 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1022124332221860566}
+  - component: {fileID: 1592630744727539676}
   - component: {fileID: 3857333942012257283}
   - component: {fileID: 5472813065106778144}
-  - component: {fileID: 1592630744727539676}
   m_Layer: 8
   m_Name: MonsterEliteLongRangePrefab
   m_TagString: Monster
@@ -35,6 +35,35 @@ Transform:
   - {fileID: 6818537091248078869}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1592630744727539676
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7512927405108858682}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c57ced2339e748958ba038a7236a510, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  myType: 0
+  _monsterData: {fileID: 11400000, guid: 41bf33f2833a142a4a5d5d18f6825b55, type: 2}
+  _monsterBulletPrefab: {fileID: 4130157634977493257, guid: 7b3fc1aa656114442acfa51848a40af6, type: 3}
+  _expBox: {fileID: 7703086083745402384, guid: d4e304cf3b1f049619280b63ac734983, type: 3}
+  MonsterHP: 0
+  _currentState: 0
+  _renderer: {fileID: 7361896321199305009}
+  _attackPoint: {fileID: 1022124332221860566}
+  _boom: {fileID: 6516240114102030008, guid: 37e7401034c044df0918e1f181bf72e4, type: 3}
+  _boomCollider: {fileID: 7107076862786558208, guid: 1fc2125f6450945478dfe55bc1575004, type: 3}
+  _playerAttack: {fileID: 0}
+  _monsterSpeed: 0
+  _attackRange: 0
+  _attackinterval: 0
+  _attackSpeed: 0
+  _exp: 0
+  monsterHP: 0
 --- !u!65 &3857333942012257283
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -78,28 +107,6 @@ NavMeshAgent:
   m_BaseOffset: 0.5
   m_WalkableMask: 4294967295
   m_ObstacleAvoidanceType: 2
---- !u!114 &1592630744727539676
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7512927405108858682}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6c57ced2339e748958ba038a7236a510, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  myType: 0
-  _monsterData: {fileID: 11400000, guid: 41bf33f2833a142a4a5d5d18f6825b55, type: 2}
-  _monsterBulletPrefab: {fileID: 4130157634977493257, guid: 7b3fc1aa656114442acfa51848a40af6, type: 3}
-  _expBox: {fileID: 7703086083745402384, guid: d4e304cf3b1f049619280b63ac734983, type: 3}
-  MonsterHP: 0
-  _currentState: 0
-  _renderer: {fileID: 7361896321199305009}
-  _attackPoint: {fileID: 1022124332221860566}
-  _boom: {fileID: 6516240114102030008, guid: 37e7401034c044df0918e1f181bf72e4, type: 3}
-  _boomCollider: {fileID: 7107076862786558208, guid: 1fc2125f6450945478dfe55bc1575004, type: 3}
 --- !u!1001 &6425218464773285886
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -160,10 +167,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -6290453013808853080, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 671b5cee891dc49e0b4c98d85bbd9e91, type: 2}
     - target: {fileID: -4683669308469848369, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteShortRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteShortRangePrefab.prefab
@@ -53,10 +53,17 @@ MonoBehaviour:
   _expBox: {fileID: 7703086083745402384, guid: d4e304cf3b1f049619280b63ac734983, type: 3}
   MonsterHP: 0
   _currentState: 0
-  _renderer: {fileID: 6086203418545236476}
+  _renderer: {fileID: 0}
   _attackPoint: {fileID: 6021140740380600468}
   _boom: {fileID: 6516240114102030008, guid: 37e7401034c044df0918e1f181bf72e4, type: 3}
   _boomCollider: {fileID: 7107076862786558208, guid: 1fc2125f6450945478dfe55bc1575004, type: 3}
+  _playerAttack: {fileID: 0}
+  _monsterSpeed: 0
+  _attackRange: 0
+  _attackinterval: 0
+  _attackSpeed: 0
+  _exp: 0
+  monsterHP: 0
 --- !u!195 &8376100200426359010
 NavMeshAgent:
   m_ObjectHideFlags: 0
@@ -108,59 +115,59 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6021140740380600468}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.52
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalScale.y
       value: 0.52
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalScale.z
       value: 0.52
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalPosition.y
       value: -2.07
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.39999998
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.7071068
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0.7071068
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: 919132149155446097, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_Name
       value: Monster_type_A
       objectReference: {fileID: 0}
@@ -168,14 +175,9 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: d77abcd0a9227442b8235508035e3210, type: 3}
---- !u!23 &6086203418545236476 stripped
-MeshRenderer:
-  m_CorrespondingSourceObject: {fileID: -4683669308469848369, guid: d77abcd0a9227442b8235508035e3210, type: 3}
-  m_PrefabInstance: {fileID: 7743599086039301939}
-  m_PrefabAsset: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
 --- !u!4 &7853278474869676248 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
   m_PrefabInstance: {fileID: 7743599086039301939}
   m_PrefabAsset: {fileID: 0}

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteShortRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteShortRangePrefab.prefab
@@ -53,7 +53,7 @@ MonoBehaviour:
   _expBox: {fileID: 7703086083745402384, guid: d4e304cf3b1f049619280b63ac734983, type: 3}
   MonsterHP: 0
   _currentState: 0
-  _renderer: {fileID: 0}
+  _renderer: {fileID: 6086203418545236476}
   _attackPoint: {fileID: 6021140740380600468}
   _boom: {fileID: 6516240114102030008, guid: 37e7401034c044df0918e1f181bf72e4, type: 3}
   _boomCollider: {fileID: 7107076862786558208, guid: 1fc2125f6450945478dfe55bc1575004, type: 3}
@@ -115,69 +115,74 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6021140740380600468}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.52
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalScale.y
       value: 0.52
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalScale.z
       value: 0.52
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalPosition.y
       value: -2.07
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.39999998
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.7071068
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0.7071068
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: 919132149155446097, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_Name
-      value: Monster_type_A
+      value: Monster_type_C
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+--- !u!23 &6086203418545236476 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -4683669308469848369, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+  m_PrefabInstance: {fileID: 7743599086039301939}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &7853278474869676248 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
   m_PrefabInstance: {fileID: 7743599086039301939}
   m_PrefabAsset: {fileID: 0}

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterShortRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterShortRangePrefab.prefab
@@ -75,7 +75,7 @@ MonoBehaviour:
   _expBox: {fileID: 7703086083745402384, guid: d4e304cf3b1f049619280b63ac734983, type: 3}
   MonsterHP: 0
   _currentState: 0
-  _renderer: {fileID: 0}
+  _renderer: {fileID: 5885082883639157140}
   _attackPoint: {fileID: 7568059509539987083}
   _boom: {fileID: 6516240114102030008, guid: 37e7401034c044df0918e1f181bf72e4, type: 3}
   _boomCollider: {fileID: 7107076862786558208, guid: 1fc2125f6450945478dfe55bc1575004, type: 3}
@@ -115,73 +115,78 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 7568059509539987083}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.2606796
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalScale.y
       value: 0.26067
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalScale.z
       value: 0.26067
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalPosition.y
       value: -1.522
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.147
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.7071068
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0.7071068
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 90
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_ConstrainProportionsScale
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+    - target: {fileID: 919132149155446097, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_Name
-      value: Monster_type_A
+      value: Monster_type_C
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+--- !u!23 &5885082883639157140 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -4683669308469848369, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+  m_PrefabInstance: {fileID: 7974819580680501083}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &7577017590203486384 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
   m_PrefabInstance: {fileID: 7974819580680501083}
   m_PrefabAsset: {fileID: 0}

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterShortRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterShortRangePrefab.prefab
@@ -75,10 +75,17 @@ MonoBehaviour:
   _expBox: {fileID: 7703086083745402384, guid: d4e304cf3b1f049619280b63ac734983, type: 3}
   MonsterHP: 0
   _currentState: 0
-  _renderer: {fileID: 5885082883639157140}
+  _renderer: {fileID: 0}
   _attackPoint: {fileID: 7568059509539987083}
   _boom: {fileID: 6516240114102030008, guid: 37e7401034c044df0918e1f181bf72e4, type: 3}
   _boomCollider: {fileID: 7107076862786558208, guid: 1fc2125f6450945478dfe55bc1575004, type: 3}
+  _playerAttack: {fileID: 0}
+  _monsterSpeed: 0
+  _attackRange: 0
+  _attackinterval: 0
+  _attackSpeed: 0
+  _exp: 0
+  monsterHP: 0
 --- !u!65 &6483792415486631229
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -108,63 +115,63 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 7568059509539987083}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.2606796
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalScale.y
       value: 0.26067
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalScale.z
       value: 0.26067
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalPosition.y
       value: -1.522
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.147
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.7071068
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0.7071068
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 90
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_ConstrainProportionsScale
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+    - target: {fileID: 919132149155446097, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
       propertyPath: m_Name
       value: Monster_type_A
       objectReference: {fileID: 0}
@@ -172,14 +179,9 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: d77abcd0a9227442b8235508035e3210, type: 3}
---- !u!23 &5885082883639157140 stripped
-MeshRenderer:
-  m_CorrespondingSourceObject: {fileID: -4683669308469848369, guid: d77abcd0a9227442b8235508035e3210, type: 3}
-  m_PrefabInstance: {fileID: 7974819580680501083}
-  m_PrefabAsset: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
 --- !u!4 &7577017590203486384 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d77abcd0a9227442b8235508035e3210, type: 3}
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: f976d6aae64914d34a417f27dc87e855, type: 3}
   m_PrefabInstance: {fileID: 7974819580680501083}
   m_PrefabAsset: {fileID: 0}

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Prefabs/Space/AttackPrefab/Bomb/BombOnMonster.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Prefabs/Space/AttackPrefab/Bomb/BombOnMonster.prefab
@@ -169,7 +169,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 5888463973503966218, guid: 4153c9e38bb5e46a5ac74a338f7fdbe7, type: 3}
+  - {fileID: -3963241562183589234, guid: 08e0ca56a5135449ba7b10674a6bf02b, type: 3}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/ProjectDaNyan/Packages/manifest.json
+++ b/ProjectDaNyan/Packages/manifest.json
@@ -9,6 +9,7 @@
     "com.unity.collab-proxy": "2.0.7",
     "com.unity.device-simulator.devices": "1.0.0",
     "com.unity.feature.development": "1.0.1",
+    "com.unity.ide.rider": "3.0.26",
     "com.unity.postprocessing": "3.2.2",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.5",

--- a/ProjectDaNyan/Packages/packages-lock.json
+++ b/ProjectDaNyan/Packages/packages-lock.json
@@ -89,7 +89,7 @@
     },
     "com.unity.ext.nunit": {
       "version": "1.0.6",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -109,8 +109,8 @@
       }
     },
     "com.unity.ide.rider": {
-      "version": "3.0.24",
-      "depth": 1,
+      "version": "3.0.26",
+      "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.unity.ext.nunit": "1.0.6"


### PR DESCRIPTION
변경 사항 : 
- MonsterNormal 스크립트 Renderer 에 missmatch 된 부분 수정을 위해 모든 몹들의 오브젝트를 통일 (monster type a)
- bomb on attack missing material 대응을 위해 임시 메터리얼 적용
- 몬스터 프리펩 중 missing 메시를 monster type a 로 통일
- 라이더 ide unity 패키지 업데이트