### PR TITLE
improve: 플레이어 바위 및 이동 시스템 전반적인 1차 개선

### DIFF
--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Models/02.Element/Load/rock.fbx.meta
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Models/02.Element/Load/rock.fbx.meta
@@ -32,7 +32,7 @@ ModelImporter:
     extraExposedTransformPaths: []
     extraUserProperties: []
     clipAnimations: []
-    isReadable: 0
+    isReadable: 1
   meshes:
     lODScreenPercentages: []
     globalScale: 1

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_01.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_01.prefab
@@ -49,93 +49,75 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6131854605310599556}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_LocalScale.x
       value: 21.062479
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_LocalScale.y
       value: 21.062479
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_LocalScale.z
       value: 21.062479
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_LocalPosition.x
       value: 4.37
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_LocalPosition.y
       value: 4.98
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_LocalPosition.z
       value: -15.71
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0.00000008146034
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: -7511558181221131132, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: d99ce68f7a5184e7083988a462e1946b, type: 2}
-    - target: {fileID: -7511558181221131132, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: -7511558181221131132, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_Materials.Array.data[1]
       value: 
       objectReference: {fileID: 2100000, guid: a322b874917ab4eaca8a12313263ae42, type: 2}
-    - target: {fileID: 919132149155446097, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_Name
       value: 01_board frame
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_TagString
       value: Prop
       objectReference: {fileID: 0}
-    - target: {fileID: 7580383460486145222, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - target: {fileID: 7580383460486145222, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 06d40dc2e1401784eb420a0d2d5d7235, type: 2}
@@ -143,15 +125,13 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
       insertIndex: -1
       addedObject: {fileID: 7524165733645528319}
   m_SourcePrefab: {fileID: 100100000, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
 --- !u!1 &1569233643779344390 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
   m_PrefabInstance: {fileID: 1803234798160999767}
   m_PrefabAsset: {fileID: 0}
 --- !u!65 &7524165733645528319
@@ -177,8 +157,7 @@ BoxCollider:
   m_Center: {x: -0.00000001862645, y: 0.00000007823109, z: -0.000000019092111}
 --- !u!4 &2201372928170201788 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 704ff1c6b784247248ffa8c1927e2bb8, type: 3}
   m_PrefabInstance: {fileID: 1803234798160999767}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3373072415334312456
@@ -189,93 +168,75 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6131854605310599556}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalScale.x
       value: 3.0555198
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalScale.y
       value: 3.0555198
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalScale.z
       value: 3.0555198
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalPosition.x
       value: -7.19
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.74
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalPosition.z
       value: 14.25
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.7071068
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0.7071068
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 90
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: d99ce68f7a5184e7083988a462e1946b, type: 2}
-    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Materials.Array.data[1]
       value: 
       objectReference: {fileID: 2100000, guid: 069d9f5e36b3a412eab33da530e7f5eb, type: 2}
-    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Name
       value: 01_barrier
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Layer
       value: 10
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_TagString
       value: Wall
       objectReference: {fileID: 0}
@@ -283,15 +244,13 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       insertIndex: -1
       addedObject: {fileID: 4556284606898680051}
   m_SourcePrefab: {fileID: 100100000, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
 --- !u!1 &2454152475144787801 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
   m_PrefabInstance: {fileID: 3373072415334312456}
   m_PrefabAsset: {fileID: 0}
 --- !u!65 &4556284606898680051
@@ -317,8 +276,7 @@ BoxCollider:
   m_Center: {x: -0.0000019073489, y: 0.5090637, z: 0.0000038743024}
 --- !u!4 &2973842506654338531 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
   m_PrefabInstance: {fileID: 3373072415334312456}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3458451357736011679
@@ -329,98 +287,79 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6131854605310599556}
     m_Modifications:
-    - target: {fileID: 1452315914603209929, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 1452315914603209929, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalScale.x
       value: 9.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1452315914603209929, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 1452315914603209929, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalScale.y
       value: 9.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1452315914603209929, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 1452315914603209929, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalScale.z
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2614007393228629630, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 2614007393228629630, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.03681
       objectReference: {fileID: 0}
-    - target: {fileID: 2614007393228629630, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 2614007393228629630, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalScale.y
       value: 0.03681
       objectReference: {fileID: 0}
-    - target: {fileID: 2614007393228629630, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 2614007393228629630, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_LocalScale.z
       value: 0.03681
       objectReference: {fileID: 0}
-    - target: {fileID: 2614007393228629630, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 2614007393228629630, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_ConstrainProportionsScale
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3313431889966720583, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 3313431889966720583, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_Name
       value: MapFloor
       objectReference: {fileID: 0}
-    - target: {fileID: 3313431889966720583, guid: b53604d60fa431f48abd571eade7ac8a,
-        type: 3}
+    - target: {fileID: 3313431889966720583, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
       propertyPath: m_Layer
       value: 11
       objectReference: {fileID: 0}
@@ -431,8 +370,7 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
 --- !u!4 &3838542869879987841 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 1926376570102782238, guid: b53604d60fa431f48abd571eade7ac8a, type: 3}
   m_PrefabInstance: {fileID: 3458451357736011679}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3564908514698283043
@@ -443,68 +381,67 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6131854605310599556}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -7.85
+      value: -0.6
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.62
+      value: 0.6
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 26.55
+      value: 2.7
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.68090755
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0.68090767
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0.19069579
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0.1906958
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: -90
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 31.291
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_Name
       value: rock
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_Layer
       value: 10
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_TagString
       value: Rock
       objectReference: {fileID: 0}
@@ -512,21 +449,18 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       insertIndex: -1
       addedObject: {fileID: 332882167916197767}
   m_SourcePrefab: {fileID: 100100000, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
 --- !u!4 &3959684511421575112 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
   m_PrefabInstance: {fileID: 3564908514698283043}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &4447428575915046258 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
   m_PrefabInstance: {fileID: 3564908514698283043}
   m_PrefabAsset: {fileID: 0}
 --- !u!65 &332882167916197767
@@ -558,78 +492,63 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6131854605310599556}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       propertyPath: m_LocalPosition.x
       value: -7.74
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.74
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       propertyPath: m_LocalPosition.z
       value: -7.01
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0.000000081460335
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - target: {fileID: -7511558181221131132, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: d99ce68f7a5184e7083988a462e1946b, type: 2}
-    - target: {fileID: -7511558181221131132, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - target: {fileID: -7511558181221131132, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       propertyPath: m_Materials.Array.data[1]
       value: 
       objectReference: {fileID: 2100000, guid: 069d9f5e36b3a412eab33da530e7f5eb, type: 2}
-    - target: {fileID: 919132149155446097, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       propertyPath: m_Name
       value: 01_tower
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       propertyPath: m_Layer
       value: 10
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       propertyPath: m_TagString
       value: BossWall
       objectReference: {fileID: 0}
@@ -637,21 +556,18 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 077a370390288496fb57b69ee4228be5,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 077a370390288496fb57b69ee4228be5, type: 3}
       insertIndex: -1
       addedObject: {fileID: 8993022535245825451}
   m_SourcePrefab: {fileID: 100100000, guid: 077a370390288496fb57b69ee4228be5, type: 3}
 --- !u!4 &3836544836193168657 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 077a370390288496fb57b69ee4228be5, type: 3}
   m_PrefabInstance: {fileID: 3653717060293905146}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &4500773465952319403 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 077a370390288496fb57b69ee4228be5,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 077a370390288496fb57b69ee4228be5, type: 3}
   m_PrefabInstance: {fileID: 3653717060293905146}
   m_PrefabAsset: {fileID: 0}
 --- !u!65 &8993022535245825451
@@ -683,93 +599,75 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6131854605310599556}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalScale.x
       value: 3.0555198
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalScale.y
       value: 3.0555198
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalScale.z
       value: 3.0555198
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0.9900024
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.74
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalPosition.z
       value: 14.25
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.7071068
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0.7071068
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 90
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: d99ce68f7a5184e7083988a462e1946b, type: 2}
-    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Materials.Array.data[1]
       value: 
       objectReference: {fileID: 2100000, guid: 069d9f5e36b3a412eab33da530e7f5eb, type: 2}
-    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Name
       value: 01_barrier
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Layer
       value: 10
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_TagString
       value: Wall
       objectReference: {fileID: 0}
@@ -777,15 +675,13 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       insertIndex: -1
       addedObject: {fileID: 3455682309426301316}
   m_SourcePrefab: {fileID: 100100000, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
 --- !u!1 &3559697665322261895 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
   m_PrefabInstance: {fileID: 4442801012090020054}
   m_PrefabAsset: {fileID: 0}
 --- !u!65 &3455682309426301316
@@ -811,8 +707,7 @@ BoxCollider:
   m_Center: {x: -0.0000009536745, y: 0.5090637, z: 0.000002920628}
 --- !u!4 &4192084370496046909 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
   m_PrefabInstance: {fileID: 4442801012090020054}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5347394571401277403
@@ -823,93 +718,75 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6131854605310599556}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalScale.x
       value: 3.0555198
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalScale.y
       value: 3.0555198
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalScale.z
       value: 3.0555198
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalPosition.x
       value: 14.53
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.74
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.94
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0.000000081460335
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: d99ce68f7a5184e7083988a462e1946b, type: 2}
-    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Materials.Array.data[1]
       value: 
       objectReference: {fileID: 2100000, guid: 069d9f5e36b3a412eab33da530e7f5eb, type: 2}
-    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Name
       value: 01_barrier
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Layer
       value: 10
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_TagString
       value: Wall
       objectReference: {fileID: 0}
@@ -917,15 +794,13 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       insertIndex: -1
       addedObject: {fileID: 8012020868487427717}
   m_SourcePrefab: {fileID: 100100000, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
 --- !u!1 &5112899313243296394 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
   m_PrefabInstance: {fileID: 5347394571401277403}
   m_PrefabAsset: {fileID: 0}
 --- !u!65 &8012020868487427717
@@ -951,8 +826,7 @@ BoxCollider:
   m_Center: {x: -0.0000019073486, y: 0.5090637, z: 0.0000019669533}
 --- !u!4 &5602331128301406256 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
   m_PrefabInstance: {fileID: 5347394571401277403}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5661370099342072835
@@ -963,78 +837,63 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6131854605310599556}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.067020744
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
       propertyPath: m_LocalScale.y
       value: 0.067020744
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
       propertyPath: m_LocalScale.z
       value: 0.067020744
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
       propertyPath: m_LocalPosition.x
       value: 1.309288
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
       propertyPath: m_LocalPosition.y
       value: 2.67
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
       propertyPath: m_LocalPosition.z
       value: -8.695484
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.12314105
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0.9923892
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: -165.853
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -751651130984038261, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-        type: 3}
+    - target: {fileID: -751651130984038261, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 4faab77a81987452f8e228dbae970854, type: 2}
-    - target: {fileID: 919132149155446097, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
       propertyPath: m_Name
       value: Player_cat_walking
       objectReference: {fileID: 0}
@@ -1045,8 +904,7 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
 --- !u!4 &5267948643116137448 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 288ba551dfebf41b2bc7c6ed7e63519d, type: 3}
   m_PrefabInstance: {fileID: 5661370099342072835}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7066614672159737787
@@ -1057,68 +915,71 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6131854605310599556}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
       value: 15.145214
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.92
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.z
       value: -15.145
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.68090755
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0.68090767
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0.19069579
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0.1906958
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: -90
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 31.291
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_Name
       value: rock
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_Layer
       value: 10
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_TagString
       value: Rock
       objectReference: {fileID: 0}
@@ -1126,21 +987,18 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       insertIndex: -1
       addedObject: {fileID: 2621639346464604847}
   m_SourcePrefab: {fileID: 100100000, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
 --- !u!4 &7321465307017011280 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
   m_PrefabInstance: {fileID: 7066614672159737787}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &7985094669185333994 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
   m_PrefabInstance: {fileID: 7066614672159737787}
   m_PrefabAsset: {fileID: 0}
 --- !u!65 &2621639346464604847
@@ -1172,93 +1030,75 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6131854605310599556}
     m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalScale.x
       value: 3.0555198
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalScale.y
       value: 3.0555198
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalScale.z
       value: 3.0555198
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalPosition.x
       value: 14.529999
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.74
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalPosition.z
       value: 6.0699997
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0.000000081460335
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: d99ce68f7a5184e7083988a462e1946b, type: 2}
-    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: -7511558181221131132, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Materials.Array.data[1]
       value: 
       objectReference: {fileID: 2100000, guid: 069d9f5e36b3a412eab33da530e7f5eb, type: 2}
-    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Name
       value: 01_barrier
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_Layer
       value: 10
       objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - target: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       propertyPath: m_TagString
       value: Wall
       objectReference: {fileID: 0}
@@ -1266,15 +1106,13 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
       insertIndex: -1
       addedObject: {fileID: 981179614733849551}
   m_SourcePrefab: {fileID: 100100000, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
 --- !u!1 &8374550639384685968 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
   m_PrefabInstance: {fileID: 8717008167131041985}
   m_PrefabAsset: {fileID: 0}
 --- !u!65 &981179614733849551
@@ -1300,7 +1138,6 @@ BoxCollider:
   m_Center: {x: -0.0000019073486, y: 0.5090637, z: 0.0000019669533}
 --- !u!4 &9183879517099996970 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: c23e45b38bf46444d8263f0b601ae336, type: 3}
   m_PrefabInstance: {fileID: 8717008167131041985}
   m_PrefabAsset: {fileID: 0}

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_02.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_02.prefab
@@ -351,7 +351,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 4bfcba2fe21a34ea8a74956a7e2b22f8, type: 3}
       propertyPath: m_TagString
-      value: Rock
+      value: BossWall
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -529,7 +529,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b5da1a5f2282d4394b18970fed0fa7e2, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.26
+      value: 0.3
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b5da1a5f2282d4394b18970fed0fa7e2, type: 3}
       propertyPath: m_LocalPosition.z
@@ -573,7 +573,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: b5da1a5f2282d4394b18970fed0fa7e2, type: 3}
       propertyPath: m_Layer
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: b5da1a5f2282d4394b18970fed0fa7e2, type: 3}
       propertyPath: m_TagString
@@ -581,7 +581,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1291338072459546520, guid: b5da1a5f2282d4394b18970fed0fa7e2, type: 3}
       propertyPath: m_Layer
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 4678280234601233816, guid: b5da1a5f2282d4394b18970fed0fa7e2, type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -634,6 +634,18 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 2328103594176347855}
     m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
       value: -11.59
@@ -861,7 +873,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: da932c9400f0e4ba290480ae93362e1b, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.46
+      value: 0.36
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: da932c9400f0e4ba290480ae93362e1b, type: 3}
       propertyPath: m_LocalPosition.z
@@ -913,7 +925,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: da932c9400f0e4ba290480ae93362e1b, type: 3}
       propertyPath: m_Layer
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: da932c9400f0e4ba290480ae93362e1b, type: 3}
       propertyPath: m_TagString

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_03.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_03.prefab
@@ -114,7 +114,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: f114e15aa3da94e32b441c044e5157cc, type: 3}
       propertyPath: m_TagString
-      value: Rock
+      value: BossWall
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -315,7 +315,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: f114e15aa3da94e32b441c044e5157cc, type: 3}
       propertyPath: m_TagString
-      value: Rock
+      value: BossWall
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -611,16 +611,28 @@ PrefabInstance:
     m_TransformParent: {fileID: 3843045850928290247}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -14.58
+      value: -12.2
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.92
+      value: 0.9
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 5.1
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.w
@@ -943,6 +955,18 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 3843045850928290247}
     m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
       value: 15.4

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_04.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_04.prefab
@@ -189,7 +189,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 100000, guid: 763e44680c9814043964dd96f7a10e64, type: 3}
       propertyPath: m_Layer
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 100000, guid: 763e44680c9814043964dd96f7a10e64, type: 3}
       propertyPath: m_TagString
@@ -213,7 +213,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 763e44680c9814043964dd96f7a10e64, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.02
+      value: 0.61
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 763e44680c9814043964dd96f7a10e64, type: 3}
       propertyPath: m_LocalPosition.z
@@ -443,7 +443,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: bbc28bfffde7b4bcda51d618aa5f34a8, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.84
+      value: 0.64
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: bbc28bfffde7b4bcda51d618aa5f34a8, type: 3}
       propertyPath: m_LocalPosition.z

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_05.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_05.prefab
@@ -765,16 +765,28 @@ PrefabInstance:
     m_TransformParent: {fileID: 4863674441924539784}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -7.09
+      value: -12
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.83
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 11.28
+      value: 2.9
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.w
@@ -873,7 +885,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 100000, guid: fe0cf25486cce41f09b07dd8cb7e91de, type: 3}
       propertyPath: m_TagString
-      value: Rock
+      value: BossWall
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: fe0cf25486cce41f09b07dd8cb7e91de, type: 3}
       propertyPath: m_LocalScale.x
@@ -1102,7 +1114,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 100000, guid: ce783d04546494dbe83295b8667f3d4d, type: 3}
       propertyPath: m_TagString
-      value: Wall
+      value: BossWall
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: ce783d04546494dbe83295b8667f3d4d, type: 3}
       propertyPath: m_LocalScale.x
@@ -1118,15 +1130,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: ce783d04546494dbe83295b8667f3d4d, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 9.9
+      value: 8.6
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: ce783d04546494dbe83295b8667f3d4d, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.74
+      value: 0.7
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: ce783d04546494dbe83295b8667f3d4d, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 5.55
+      value: 13.1
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: ce783d04546494dbe83295b8667f3d4d, type: 3}
       propertyPath: m_LocalRotation.w
@@ -1212,16 +1224,28 @@ PrefabInstance:
     m_TransformParent: {fileID: 4863674441924539784}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -24.59
+      value: 10.2
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.64
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -24.97
+      value: 0.7
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.w

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_06.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_06.prefab
@@ -63,7 +63,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: db9e3abab0ca8414db41e0d1e296eb1e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -8.47
+      value: -9
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: db9e3abab0ca8414db41e0d1e296eb1e, type: 3}
       propertyPath: m_LocalPosition.y
@@ -71,7 +71,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: db9e3abab0ca8414db41e0d1e296eb1e, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 15.01
+      value: 15.46
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: db9e3abab0ca8414db41e0d1e296eb1e, type: 3}
       propertyPath: m_LocalRotation.w
@@ -123,7 +123,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: db9e3abab0ca8414db41e0d1e296eb1e, type: 3}
       propertyPath: m_TagString
-      value: Rock
+      value: Prop
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -350,15 +350,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: da2d6db14f8f14a78844a2cacd7f8f3e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -2.52
+      value: -5.2
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: da2d6db14f8f14a78844a2cacd7f8f3e, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.65
+      value: 2.6
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: da2d6db14f8f14a78844a2cacd7f8f3e, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -11.93
+      value: -13.9
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: da2d6db14f8f14a78844a2cacd7f8f3e, type: 3}
       propertyPath: m_LocalRotation.w
@@ -418,7 +418,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: da2d6db14f8f14a78844a2cacd7f8f3e, type: 3}
       propertyPath: m_TagString
-      value: Rock
+      value: BossWall
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -812,6 +812,18 @@ PrefabInstance:
     m_TransformParent: {fileID: 6371379803092186221}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
       value: 10
       objectReference: {fileID: 0}
@@ -924,7 +936,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: db9e3abab0ca8414db41e0d1e296eb1e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -11.58
+      value: -13.45
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: db9e3abab0ca8414db41e0d1e296eb1e, type: 3}
       propertyPath: m_LocalPosition.y
@@ -932,7 +944,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: db9e3abab0ca8414db41e0d1e296eb1e, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 13.2
+      value: 16.84
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: db9e3abab0ca8414db41e0d1e296eb1e, type: 3}
       propertyPath: m_LocalRotation.w
@@ -984,7 +996,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: db9e3abab0ca8414db41e0d1e296eb1e, type: 3}
       propertyPath: m_TagString
-      value: Wall
+      value: BossWall
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1034,8 +1046,20 @@ PrefabInstance:
     m_TransformParent: {fileID: 6371379803092186221}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -24.59
+      value: -9.64
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.y
@@ -1043,7 +1067,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -24.97
+      value: 3.59
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.w

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_07.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_07.prefab
@@ -451,6 +451,10 @@ PrefabInstance:
       value: BossWall
       objectReference: {fileID: 0}
     - target: {fileID: 3199641718464332858, guid: 78d8c5a8b62dd44e4bf636bc2d625167, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3199641718464332858, guid: 78d8c5a8b62dd44e4bf636bc2d625167, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 2dc5effd4b8954c25aa2a6277ae1f48b, type: 2}

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_08.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_08.prefab
@@ -61,15 +61,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3c3c9c1da81e446c3bb6294a82de5280, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 11.33
+      value: 14.6
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3c3c9c1da81e446c3bb6294a82de5280, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.57
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3c3c9c1da81e446c3bb6294a82de5280, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.91
+      value: -11
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3c3c9c1da81e446c3bb6294a82de5280, type: 3}
       propertyPath: m_LocalRotation.w
@@ -236,7 +236,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 8050d4000fb474f9bad1bd74303f5dd2, type: 3}
       propertyPath: m_TagString
-      value: Wall
+      value: Prop
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -299,15 +299,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 95a201a3eb6084190a58af459587898f, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 8.75
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 95a201a3eb6084190a58af459587898f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.78
+      value: 4.2
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 95a201a3eb6084190a58af459587898f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 20.55
+      value: 15.1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 95a201a3eb6084190a58af459587898f, type: 3}
       propertyPath: m_LocalRotation.w
@@ -359,7 +359,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 95a201a3eb6084190a58af459587898f, type: 3}
       propertyPath: m_TagString
-      value: Rock
+      value: BossWall
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -532,16 +532,28 @@ PrefabInstance:
     m_TransformParent: {fileID: 2519863377337423927}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -16.46
+      value: 2.6
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.86
+      value: 0.9
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -16.01
+      value: -4.6
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.w
@@ -746,8 +758,20 @@ PrefabInstance:
     m_TransformParent: {fileID: 2519863377337423927}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -25.13
+      value: -1.2
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.y
@@ -755,7 +779,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 10.98
+      value: 12.6
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.w

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_10.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_10.prefab
@@ -161,8 +161,20 @@ PrefabInstance:
     m_TransformParent: {fileID: 8817635428562354559}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -10.63
+      value: -3.55
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.y
@@ -170,7 +182,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 17.94
+      value: 14.69
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.w
@@ -575,6 +587,18 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 8817635428562354559}
     m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
       value: 13.3

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_11.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_11.prefab
@@ -62,15 +62,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5b77a717120d440eea99a35c0edab9f8, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -7.27
+      value: -4.2
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5b77a717120d440eea99a35c0edab9f8, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.81
+      value: 3.3
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5b77a717120d440eea99a35c0edab9f8, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 21.48
+      value: 16.2
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 5b77a717120d440eea99a35c0edab9f8, type: 3}
       propertyPath: m_LocalRotation.w
@@ -688,16 +688,28 @@ PrefabInstance:
     m_TransformParent: {fileID: 4903725143062629701}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -15.729211
+      value: -14
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.96
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 13.795158
+      value: 5.5
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.w

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_12.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_12.prefab
@@ -514,32 +514,44 @@ PrefabInstance:
     m_TransformParent: {fileID: 6881299486354710352}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 3.71
+      value: 15.6
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.61
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 26.62
+      value: 15.4
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.6146171
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.6146172
+      value: -0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.34963655
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.34963658
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -551,7 +563,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 59.268
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_Name
@@ -682,7 +694,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: f435b82f3643046849a9cfd31db3eba3, type: 3}
       propertyPath: m_Layer
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: f435b82f3643046849a9cfd31db3eba3, type: 3}
       propertyPath: m_TagString
@@ -887,7 +899,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: fba90d145ea4b4fa4b9f1a7a9d6941a2, type: 3}
       propertyPath: m_TagString
-      value: Prop
+      value: BossWall
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1002,7 +1014,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: fba90d145ea4b4fa4b9f1a7a9d6941a2, type: 3}
       propertyPath: m_TagString
-      value: Prop
+      value: BossWall
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1052,32 +1064,44 @@ PrefabInstance:
     m_TransformParent: {fileID: 6881299486354710352}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -10.3332815
+      value: -15.7
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.94
+      value: 0.9
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -13.901793
+      value: -14.1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.6955387
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.69553894
+      value: -0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.12738043
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.12738046
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1089,7 +1113,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 20.756
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_Name

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_13.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_13.prefab
@@ -46,6 +46,18 @@ PrefabInstance:
     m_TransformParent: {fileID: 3777788356982577977}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
       value: -8.44
       objectReference: {fileID: 0}

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_14.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_14.prefab
@@ -813,7 +813,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 3dc1860f9c40f462fa00b49d68e1751d, type: 3}
       propertyPath: m_TagString
-      value: Rock
+      value: BossWall
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_15.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_15.prefab
@@ -173,7 +173,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 100000, guid: 9b831894b52514255ab34eba05421ecb, type: 3}
       propertyPath: m_Layer
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 100000, guid: 9b831894b52514255ab34eba05421ecb, type: 3}
       propertyPath: m_TagString
@@ -283,16 +283,28 @@ PrefabInstance:
     m_TransformParent: {fileID: 6570118613620687598}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -15.57
+      value: -13.5
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.62
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -25.9
+      value: -10.3
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalRotation.w
@@ -381,6 +393,18 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6570118613620687598}
     m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
       value: 15.5
@@ -600,7 +624,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 100000, guid: c20bee561b8ad43ad8c7973ede21bdf6, type: 3}
       propertyPath: m_TagString
-      value: Wall
+      value: BossWall
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: c20bee561b8ad43ad8c7973ede21bdf6, type: 3}
       propertyPath: m_LocalScale.x

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_16.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_16.prefab
@@ -488,6 +488,18 @@ PrefabInstance:
     m_TransformParent: {fileID: 1803416944515155070}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d37cfcf6315d04fb3b282c9ca428cfc5, type: 3}
       propertyPath: m_LocalPosition.x
       value: -15.24
       objectReference: {fileID: 0}
@@ -754,7 +766,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 46669c7ab3ba24ac28ed4bbb65a2bd57, type: 3}
       propertyPath: m_TagString
-      value: Rock
+      value: Prop
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteLongRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteLongRangePrefab.prefab
@@ -167,13 +167,29 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: -8391222552659086748, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: -5568371526223589888, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
     - target: {fileID: -4683669308469848369, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: ba37fa56140d74b7f8fb83997fc407aa, type: 2}
+    - target: {fileID: -3290247662164583081, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_Name
       value: Monster_type_C
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 7202271454713460447, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_Materials.Array.data[0]

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteShortRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteShortRangePrefab.prefab
@@ -167,9 +167,25 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: -8391222552659086748, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: -5568371526223589888, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: -3290247662164583081, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_Name
       value: Monster_type_C
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterLongRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterLongRangePrefab.prefab
@@ -79,6 +79,13 @@ MonoBehaviour:
   _attackPoint: {fileID: 1022124332221860566}
   _boom: {fileID: 6516240114102030008, guid: 37e7401034c044df0918e1f181bf72e4, type: 3}
   _boomCollider: {fileID: 7107076862786558208, guid: 1fc2125f6450945478dfe55bc1575004, type: 3}
+  _playerAttack: {fileID: 0}
+  _monsterSpeed: 0
+  _attackRange: 0
+  _attackinterval: 0
+  _attackSpeed: 0
+  _exp: 0
+  monsterHP: 0
 --- !u!65 &1790176278812915998
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -160,9 +167,25 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: -8391222552659086748, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: -5568371526223589888, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: -3290247662164583081, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_Name
       value: Monster_type_C
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterShortRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterShortRangePrefab.prefab
@@ -171,9 +171,29 @@ PrefabInstance:
       propertyPath: m_ConstrainProportionsScale
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: -8391222552659086748, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: -5568371526223589888, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: -3290247662164583081, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_Name
       value: Monster_type_C
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_TagString
+      value: Monster
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Space/PlayerController.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Space/PlayerController.cs
@@ -1,4 +1,5 @@
 using System;
+using Unity.VisualScripting.Dependencies.NCalc;
 using UnityEngine;
 
 public class PlayerController : MonoBehaviour
@@ -11,8 +12,6 @@ public class PlayerController : MonoBehaviour
     
     [SerializeField] private JoystickController _joy;
     [SerializeField] private PlayerState _playerState;
-
-    [SerializeField] private float rockHeight;
     
     [SerializeField] private Animator playerAnim;
 
@@ -41,6 +40,7 @@ public class PlayerController : MonoBehaviour
     private float jumpForce = 300;
     private float timeBeforeNextJump = 1.2f;
     private float canJump = 0f;
+    private float rockHeight = 4.0f;
 
     private float playerRotationPositionX;
     private float playerRotationPositionY;
@@ -66,7 +66,7 @@ public class PlayerController : MonoBehaviour
     {
         PlayerRotate();
         PlayerFall();
-        
+
         switch (_playerState.getPsData())
         {
             case PlayerState.PSData.walk:
@@ -141,37 +141,48 @@ public class PlayerController : MonoBehaviour
     {
         if (dashTimerCount == 0)
         {
+            playerTrailRenderer.emitting = true;
             playerAnim.SetInteger("State",2);
             playerBodyBullet.SetActive(true);
-            playerTrailRenderer.emitting = true;
             playerLineRenderer.enabled = false;
+        }
+
+        if (this.gameObject.layer == 7)
+        {
+            playerCharacterController.Move(new Vector3(dashMovePosition.x,_floatingPosition,dashMovePosition.z));
+        }
+        else
+        {
             this.gameObject.layer = 7;
+            playerCharacterController.Move(new Vector3(dashMovePosition.x,_floatingPosition,dashMovePosition.z));
         }
         
-        playerCharacterController.Move(new Vector3(dashMovePosition.x,_floatingPosition,dashMovePosition.z));
-        dashTimerCount += 1;
-            
         if (dashTimerCount >= _playerData.dashLimitTic1SecondsTo50)
         {
             PlayerDashEnds();
+            return;
         }
+        
+        dashTimerCount += 1;
     }
 
     void PlayerFall()
     {
-        if (playerCharacterController.isGrounded == false && _floatingPosition >= 0f)
+        if (playerCharacterController.isGrounded == false)
         {
-            _floatingPosition += -9.81f * Time.deltaTime;
+            if (this.transform.position.y > 0f)
+            { 
+                _floatingPosition += -9.81f * Time.deltaTime; 
+            }
         }
         else
-        { 
+        {
             _floatingPosition = 0f;
         }
     }
 
     void PlayerMovingControllOnTheRock()
     {
-        rockQuitTimerCount += 1;
         Vector3 normalized = new Vector3(_joy.Horizontal+_joy.Vertical, 0, _joy.Vertical-_joy.Horizontal).normalized;
 
         playerLineRenderer.enabled = true;
@@ -187,7 +198,9 @@ public class PlayerController : MonoBehaviour
         {
             rockQuitTimerCount = 0;
             _playerState.setPsData(PlayerState.PSData.exitStartFromRock);
+            return;
         }
+        rockQuitTimerCount += 1;
     }
 
     // void PlayerWallReflection(Collision wall)
@@ -199,12 +212,13 @@ public class PlayerController : MonoBehaviour
 
     private void PlayerDashEnds()
     {
-        dashTimerCount = 0;
         _playerState.setPsData(PlayerState.PSData.stop);
         this.gameObject.layer = 6;
         playerTrailRenderer.emitting = false;
         playerAnim.SetInteger("State",0);
         playerBodyBullet.SetActive(false);
+        dashTimerCount = 0;
+        Debug.Log(dashTimerCount+"대시종료");
     }
 
     void PlayerMoveOnTheRock(GameObject rock)
@@ -219,9 +233,10 @@ public class PlayerController : MonoBehaviour
     
     void PlayerExitStartFromRock()
     {
+        playerBodyBullet.SetActive(true);
         playerAnim.SetInteger("State",2);
         playerLineRenderer.enabled = false;
-        transform.position = new Vector3(transform.position.x, y:transform.position.y - rockHeight, transform.position.z);
+        transform.position = new Vector3(transform.position.x, y:1.3f, transform.position.z);
         _joy.PlayDashSound();
         _playerState.setPsData(PlayerState.PSData.exitDashFromRock);
     }
@@ -257,13 +272,14 @@ public class PlayerController : MonoBehaviour
             {
                 PlayerMoveOnTheRock(hit.gameObject);
             }
-            else if (hit.gameObject.layer == 11)
+            else if (hit.gameObject.layer == 11 || hit.gameObject.layer == 8)
             {
                 return;
             }
             else
             {
                 PlayerDashEnds();
+                dashTimerCount -= 1;
             }
         }
     }

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/UI/ControllerUI/Base/JoystickController.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/UI/ControllerUI/Base/JoystickController.cs
@@ -8,9 +8,11 @@ using UnityEngine.Serialization;
 public class JoystickController : FloatingJoystick
 {
     protected internal bool isJoystickPositionGoEnd = false;
-    
+
+    private GameObject player;
     private PlayerState _playerState;
     private PlayerStatus _playerStatus;
+    private PlayerController _playerController;
     private SoundEffectController _soundEffectController;
 
     private bool dashEffectToggle = true;
@@ -18,9 +20,10 @@ public class JoystickController : FloatingJoystick
     protected override void Start()
     {
         base.Start();
-        GameObject player = GameObject.FindGameObjectWithTag("Player").gameObject;
+        player = GameObject.FindGameObjectWithTag("Player").gameObject;
         _playerState = player.GetComponent<PlayerState>();
         _playerStatus = player.GetComponent<PlayerStatus>();
+        _playerController = player.GetComponent<PlayerController>();
         _soundEffectController = player.GetComponent<SoundEffectController>();
     }
     
@@ -40,6 +43,7 @@ public class JoystickController : FloatingJoystick
             {
                 if (_playerStatus.DashCharged > 0)
                 {
+                    player.gameObject.layer = 7;
                     _playerState.setPsData(PlayerState.PSData.dash);
                     _playerStatus.DashCharged -= 1;
                     PlayDashSound();


### PR DESCRIPTION
작업 내역 :
1. 맵에 있는 바위 전반적 재배치
2. 맵에 있는 각종 오브젝트 목적에 맞게 태그 재배치
3. 플레이어가 일반몬스터 전투 시 맵 뚫고 내려가면서 떨어지는 현상 발생 원인 파악
4. 대시하다가 오브젝트에 닿은 후 다시 대시하면 트레일렌더러 안 나오는 버그 수정 : 그러나 미봉책. 조만간 대시 시스템을 생애주기 방식으로 바꿔야 할듯
5. 바위 높이에 맞게 플레이어 바위에 올라가고 내려가는 시스템 개선

작업 더 해야 하는 내역 (내일 작업할 예정)
1. 플레이어가 몬스터에 낑겨서 압착되지 않게 하기 (이러면 즉사판정을 내던가 해야 할듯) - 현재 플레이어가 몬스터에 압착되면 위 혹은 아래 방향으로 밀려나는데, 이때 바닥 아래쪽으로 밀려나면 그대로 맵 아래로 추락하는 것임
2. 몬스터가 많은 상황에서 대시를 하면 대시 판정이 먼저 발생하고 그 뒤에 레이어 변경이 일어나거나, 혹은 대시가 끝나기 전에 레이어가 변경되어 플레이어가 대시하다가 목표 지점까지 가지 못하고 몬스터한테 가로막히는 현상이 발생. 어떻게 해결해야 할지 상당히 막막한 상황임.

애매한 버그 (버그인지 아닌지 확실하지 않음)
1. 바위에서 사출과 동시에 대시 시전하면 2단대시 나감 (대시 횟수가 남아 있다면)
2. 간헐적으로 바위에서 좀더 일찍 사출되는 경우가 있는데 이게 트랙패드로 컨트롤하다가 내 손이 꼬여서 그렇게 된 건지 잘 모르겠음.