### PR TITLE
Fix: 플레이어 HP바 화면에서 진동하는 현상, 플레이어 HP 위치 플레이어 상단으로 이동, 맨홀 오브젝트 레이어 변경

### DIFF
--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_07.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_07.prefab
@@ -162,7 +162,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: a78eb2aa69fbc4e89af72adb137020f2, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.521
+      value: 0.52
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: a78eb2aa69fbc4e89af72adb137020f2, type: 3}
       propertyPath: m_LocalPosition.z
@@ -206,7 +206,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a78eb2aa69fbc4e89af72adb137020f2, type: 3}
       propertyPath: m_Layer
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a78eb2aa69fbc4e89af72adb137020f2, type: 3}
       propertyPath: m_TagString

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_09.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_09.prefab
@@ -406,7 +406,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a78eb2aa69fbc4e89af72adb137020f2, type: 3}
       propertyPath: m_Layer
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a78eb2aa69fbc4e89af72adb137020f2, type: 3}
       propertyPath: m_TagString

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_10.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_10.prefab
@@ -1002,7 +1002,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a78eb2aa69fbc4e89af72adb137020f2, type: 3}
       propertyPath: m_Layer
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a78eb2aa69fbc4e89af72adb137020f2, type: 3}
       propertyPath: m_TagString

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_12.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_12.prefab
@@ -112,7 +112,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a78eb2aa69fbc4e89af72adb137020f2, type: 3}
       propertyPath: m_Layer
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a78eb2aa69fbc4e89af72adb137020f2, type: 3}
       propertyPath: m_TagString

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_13.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_13.prefab
@@ -218,7 +218,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a78eb2aa69fbc4e89af72adb137020f2, type: 3}
       propertyPath: m_Layer
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a78eb2aa69fbc4e89af72adb137020f2, type: 3}
       propertyPath: m_TagString

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_14.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_14.prefab
@@ -337,7 +337,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a78eb2aa69fbc4e89af72adb137020f2, type: 3}
       propertyPath: m_Layer
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: a78eb2aa69fbc4e89af72adb137020f2, type: 3}
       propertyPath: m_TagString

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/UI/StageUI/PlayerExpSlider.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/UI/StageUI/PlayerExpSlider.cs
@@ -16,7 +16,7 @@ namespace ProjectDaNyan.Scripts.UI.StageUI
             _playerHpSlider = GetComponent<Slider>();
         }
 
-        private void Update()
+        private void FixedUpdate()
         {
             _playerHpSlider.value = (float)_playerStatus.Player_Now_HP / _playerStatus.Player_Max_HP;
             Move();
@@ -25,7 +25,7 @@ namespace ProjectDaNyan.Scripts.UI.StageUI
         private void Move()
         {
             _playerHpSlider.transform.position =
-                Camera.main.WorldToScreenPoint(_player.transform.position + new Vector3(0, -2f, 0));
+                Camera.main.WorldToScreenPoint(_player.transform.position + new Vector3(0, 4.5f, 0));
         }
     }
 }


### PR DESCRIPTION
작업 내역:
1. 플레이어 HP바가 화면에서 진동 > Update 문을 FixedUpdate 문으로 변경
2. 플레이어 HP 위치 플레이어 상단으로 이동
3. 맨홀 오브젝트가 맵 플로어가 아니라 맵 오브젝트로 설정되어 있어서 대시할 때 닿으면 대시 끊김 > 맵 플로어로 레이어 수정