### PR TITLE
Fix: 플레이어가 경험치 오브젝트 타고 허공답보

### DIFF
--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/EXPBox.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/EXPBox.prefab
@@ -15,8 +15,7 @@ GameObject:
   - component: {fileID: 7727609116909889756}
   - component: {fileID: 7965975219053388132}
   - component: {fileID: 5532538831822095849}
-  - component: {fileID: 5727685188903578359}
-  - component: {fileID: 2037458738182223159}
+  - component: {fileID: 6721862226773484621}
   m_Layer: 0
   m_Name: EXPBox
   m_TagString: EXPBox
@@ -117,6 +116,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _magnetData: {fileID: 11400000, guid: 8eaa4d1440f404569bc79329fb5c8154, type: 2}
+  isMagnetize: 1
 --- !u!208 &7965975219053388132
 NavMeshObstacle:
   m_ObjectHideFlags: 0
@@ -160,28 +160,7 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!65 &5727685188903578359
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7703086083745402384}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.002325307, y: 0.002813251, z: 0.0029506097}
-  m_Center: {x: 0.00008347805, y: 0.00008555886, z: 0.00013627647}
---- !u!65 &2037458738182223159
+--- !u!65 &6721862226773484621
 BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -200,5 +179,5 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 0.002325307, y: 0.002813251, z: 0.0029506097}
-  m_Center: {x: 0.00008347805, y: 0.00008555886, z: 0.00013627647}
+  m_Size: {x: 0.0020384204, y: 0.0025749833, z: 0.0025}
+  m_Center: {x: 0.0001866871, y: 0.000048066973, z: 0.00013627647}

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/Player.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/Player.prefab
@@ -229,6 +229,7 @@ MonoBehaviour:
   _playerState: {fileID: 8053427458890090582}
   playerRenderer: {fileID: 8133638722044627839}
   soundEffectController: {fileID: 5689850269325050876}
+  playerController: {fileID: 8430234170764179090}
   player_Level: 1
   player_Now_HP: 100
 --- !u!114 &5689850269325050876

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Space/PlayerStatus.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Space/PlayerStatus.cs
@@ -9,6 +9,7 @@ public class PlayerStatus : MonoBehaviour
     [SerializeField] private PlayerState _playerState;
     [SerializeField] private Renderer playerRenderer;
     [SerializeField] private SoundEffectController soundEffectController;
+    [SerializeField] private CharacterController playerController;
 
     private int player_HitCount = 0;
 
@@ -214,6 +215,15 @@ public class PlayerStatus : MonoBehaviour
             
             soundEffectController.playStageSoundEffect(0.5f,SoundEffectController.StageSoundTypes.Boxcat_Gold);
         }
+    }
 
+    private void OnControllerColliderHit(ControllerColliderHit hit)
+    {
+        if (hit.gameObject.CompareTag("EXPBox"))
+        {
+            ObjectPoolManager.Inst.DestroyObject(hit.gameObject);
+            player_now_EXP += 10;
+            soundEffectController.playStageSoundEffect(0.5f,SoundEffectController.StageSoundTypes.Boxcat_Gold);
+        }
     }
 }


### PR DESCRIPTION
- 작업 내역

플레이어가 경험치 박스 타고 하늘을 나는 버그 수정

- 버그 원인
EXPBox의 콜라이더가 특정 각도에서 플레이어 캐릭터 컨트롤러와 우선 충돌하여
물리연산이 진행됨
그러나 아무런 처리가 이뤄지지 않음 > 경험치박스는 사라지지 않고 계속 플레이어쪽으로 향함 > 캐릭터가 경험치 타고 허공답보

- 해결 방법
EXPBox의 콜라이더를 2개 > 1개로 줄임 (isTrigger 콜라이더 제거)
경험치 먹는 판정 캐릭터컨트롤러 판정으로 코드상 변경