### PR TITLE
Improve: 밸런스 조정, 원거리 몬스터 텍스쳐 변경, 플레이어에게 경험치가 물리충돌 하는현상

### DIFF
--- a/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_11.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Maps/Prefebs/MapElement_11.prefab
@@ -881,9 +881,6 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: a118300feb14d45109c5d6c64cc0c3dc, type: 3}
       insertIndex: -1
       addedObject: {fileID: 8300870936800553322}
-    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: a118300feb14d45109c5d6c64cc0c3dc, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3706818753244274954}
   m_SourcePrefab: {fileID: 100100000, guid: a118300feb14d45109c5d6c64cc0c3dc, type: 3}
 --- !u!1 &7115886438565390586 stripped
 GameObject:
@@ -909,29 +906,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 0.24009423, y: 0.68178296, z: 0.60431296}
-  m_Center: {x: -1.2438593, y: 0.34089148, z: -0.0000055998785}
---- !u!65 &3706818753244274954
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7115886438565390586}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 0.17943498, y: 0.68178296, z: 0.60431296}
-  m_Center: {x: 1.2747353, y: 0.34089148, z: 0.0000020286188}
+  m_Size: {x: 2.753694, y: 0.6817841, z: 0.60431296}
+  m_Center: {x: 0.012941661, y: 0.34089205, z: -0.0000052718397}
 --- !u!4 &7605284198878147136 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: a118300feb14d45109c5d6c64cc0c3dc, type: 3}

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteLongRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteLongRangePrefab.prefab
@@ -62,6 +62,7 @@ MonoBehaviour:
   _expBox: {fileID: 7703086083745402384, guid: d4e304cf3b1f049619280b63ac734983, type: 3}
   _currentState: 0
   _attackPoint: {fileID: 1022124332221860566}
+  isShort: 0
 --- !u!65 &3857333942012257283
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -81,8 +82,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 3.35, y: 2.15, z: 1.8318763}
-  m_Center: {x: 0, y: 1.1000001, z: 0}
+  m_Size: {x: 3.35, y: 10.780497, z: 1.8318763}
+  m_Center: {x: 0, y: 5.415248, z: 0}
 --- !u!195 &5472813065106778144
 NavMeshAgent:
   m_ObjectHideFlags: 0

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteShortRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteShortRangePrefab.prefab
@@ -62,6 +62,7 @@ MonoBehaviour:
   _expBox: {fileID: 7703086083745402384, guid: d4e304cf3b1f049619280b63ac734983, type: 3}
   _currentState: 0
   _attackPoint: {fileID: 6021140740380600468}
+  isShort: 1
 --- !u!195 &8376100200426359010
 NavMeshAgent:
   m_ObjectHideFlags: 0
@@ -103,8 +104,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 3.35, y: 2.15, z: 1.8318763}
-  m_Center: {x: 0, y: 1.1000001, z: 0}
+  m_Size: {x: 3.35, y: 11.911131, z: 1.8318763}
+  m_Center: {x: 0, y: 5.980566, z: 0}
 --- !u!54 &6056631384003765915
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterLongRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterLongRangePrefab.prefab
@@ -84,6 +84,8 @@ MonoBehaviour:
   _expBox: {fileID: 7703086083745402384, guid: d4e304cf3b1f049619280b63ac734983, type: 3}
   _currentState: 0
   _attackPoint: {fileID: 1022124332221860566}
+  longColor: {r: 0.101960786, g: 0.101960786, b: 0.101960786, a: 1}
+  isShort: 0
 --- !u!65 &1790176278812915998
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -103,8 +105,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1.33, y: 2, z: 1}
-  m_Center: {x: 0, y: 0.5, z: 0}
+  m_Size: {x: 1.33, y: 10.306787, z: 1}
+  m_Center: {x: 0, y: 4.6533933, z: 0}
 --- !u!54 &1168645230308861768
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -208,6 +210,10 @@ PrefabInstance:
       propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: -4683669308469848369, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ba37fa56140d74b7f8fb83997fc407aa, type: 2}
     - target: {fileID: -3290247662164583081, guid: 0688d5443951f416cba8baf0a27bc26d, type: 3}
       propertyPath: m_Layer
       value: 8

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterShortRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterShortRangePrefab.prefab
@@ -84,6 +84,7 @@ MonoBehaviour:
   _expBox: {fileID: 7703086083745402384, guid: d4e304cf3b1f049619280b63ac734983, type: 3}
   _currentState: 0
   _attackPoint: {fileID: 7568059509539987083}
+  isShort: 1
 --- !u!65 &6483792415486631229
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -103,8 +104,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1.33, y: 2, z: 1}
-  m_Center: {x: 0, y: 0.5, z: 0}
+  m_Size: {x: 1.33, y: 13.694561, z: 1}
+  m_Center: {x: 0, y: 6.3472805, z: 0}
 --- !u!54 &6739086806372851411
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/Player.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/Player.prefab
@@ -175,13 +175,13 @@ CharacterController:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Height: 3
+  m_Height: 5
   m_Radius: 1
   m_SlopeLimit: 45
   m_StepOffset: 0.3
   m_SkinWidth: 0.08
   m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 1.5, z: -0.17}
+  m_Center: {x: 0, y: 1, z: -0.17}
 --- !u!114 &6667353087869614381
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -562,8 +562,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1, y: 2.7477922, z: 1}
-  m_Center: {x: 0, y: 1.248157, z: 0}
+  m_Size: {x: 1.8236238, y: 3.085046, z: 1.4040611}
+  m_Center: {x: -0.03133732, y: 1.4167839, z: -0.09112215}
 --- !u!1001 &1289221656642250242
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/Player.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/Player.prefab
@@ -370,7 +370,7 @@ AudioSource:
   Spatialize: 0
   SpatializePostEffects: 0
   Priority: 128
-  DopplerLevel: 1
+  DopplerLevel: 0
   MinDistance: 1
   MaxDistance: 500
   Pan2D: 0
@@ -459,14 +459,14 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 09c376cf71fe5404d9305b1034c68ce2, type: 3}
   m_PlayOnAwake: 1
-  m_Volume: 0.1
+  m_Volume: 0.095
   m_Pitch: 1
   Loop: 1
   Mute: 0
   Spatialize: 0
   SpatializePostEffects: 0
   Priority: 128
-  DopplerLevel: 1
+  DopplerLevel: 0
   MinDistance: 1
   MaxDistance: 500
   Pan2D: 0

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/Player.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/Player.prefab
@@ -18,6 +18,7 @@ GameObject:
   - component: {fileID: 4853398999115314500}
   - component: {fileID: 5432781030662005881}
   - component: {fileID: 6176409126218365443}
+  - component: {fileID: 8407775232990650749}
   m_Layer: 6
   m_Name: Player
   m_TagString: Player
@@ -542,6 +543,27 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!65 &8407775232990650749
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5792001150830992708}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 2.7477922, z: 1}
+  m_Center: {x: 0, y: 1.248157, z: 0}
 --- !u!1001 &1289221656642250242
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Prefabs/Global/MonsterManager.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Prefabs/Global/MonsterManager.prefab
@@ -25,7 +25,7 @@ Transform:
   m_GameObject: {fileID: 308379560689721546}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 15}
+  m_LocalPosition: {x: 0, y: 0, z: 25}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -56,7 +56,7 @@ Transform:
   m_GameObject: {fileID: 3945117894262289009}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -15}
+  m_LocalPosition: {x: 0, y: 0, z: -25}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -182,7 +182,7 @@ Transform:
   m_GameObject: {fileID: 6783350786848118465}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 15, y: 0, z: 0}
+  m_LocalPosition: {x: 25, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -213,7 +213,7 @@ Transform:
   m_GameObject: {fileID: 8796618607492476119}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -15, y: 0, z: 0}
+  m_LocalPosition: {x: -25, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Prefabs/Space/AttackPrefab/Bomb/BombOnMonster.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Prefabs/Space/AttackPrefab/Bomb/BombOnMonster.prefab
@@ -5162,7 +5162,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &5876421802174002878
 Transform:
   m_ObjectHideFlags: 0
@@ -5172,7 +5172,7 @@ Transform:
   m_GameObject: {fileID: 6785727705511440841}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -2.4217339, y: 4.317975, z: -28.92823}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children:

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Prefabs/Space/Camera.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Prefabs/Space/Camera.prefab
@@ -55,7 +55,7 @@ MonoBehaviour:
   m_Follow: {fileID: 0}
   m_Lens:
     FieldOfView: 40
-    OrthographicSize: 15
+    OrthographicSize: 25
     NearClipPlane: 0.1
     FarClipPlane: 5000
     Dutch: 0
@@ -428,7 +428,7 @@ Camera:
   far clip plane: 5000
   field of view: 40
   orthographic: 1
-  orthographic size: 15
+  orthographic size: 25
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Prefabs/UI/StagePrefab/PlayerEXPBox.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Prefabs/UI/StagePrefab/PlayerEXPBox.prefab
@@ -177,7 +177,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 155eb2d45b17a4af8ad4b5f7d2106fb8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  player: {fileID: 2012497629165759939, guid: 6c07738f856cc465b82852ece63e1e36, type: 3}
 --- !u!1 &2838207354462235352
 GameObject:
   m_ObjectHideFlags: 0
@@ -211,7 +210,7 @@ RectTransform:
   m_Father: {fileID: 1886383886625168346}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.348, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -248,7 +247,7 @@ MonoBehaviour:
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
-  m_FillAmount: 1
+  m_FillAmount: 0.348
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Prefabs/UI/StagePrefab/StageMainUI.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Prefabs/UI/StagePrefab/StageMainUI.prefab
@@ -2825,14 +2825,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4688994124535695706, guid: e15ef012e4da34f7ba369091b5363dc7, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4688994124535695706, guid: e15ef012e4da34f7ba369091b5363dc7, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4690725108002072914, guid: e15ef012e4da34f7ba369091b5363dc7, type: 3}
       propertyPath: m_Name
       value: PlayerEXPBox

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scenes/StageScene.unity
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scenes/StageScene.unity
@@ -584,9 +584,25 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 269454219}
     m_Modifications:
+    - target: {fileID: 2859591362753765699, guid: 67f2f256c2e5f46aa8965174e6b7bb48, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -25
+      objectReference: {fileID: 0}
+    - target: {fileID: 3128953194732964171, guid: 67f2f256c2e5f46aa8965174e6b7bb48, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -25
+      objectReference: {fileID: 0}
     - target: {fileID: 3948476144519111223, guid: 67f2f256c2e5f46aa8965174e6b7bb48, type: 3}
       propertyPath: m_Name
       value: MonsterManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 5197511860445037114, guid: 67f2f256c2e5f46aa8965174e6b7bb48, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 8365360019841480773, guid: 67f2f256c2e5f46aa8965174e6b7bb48, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 8374344308667646995, guid: 67f2f256c2e5f46aa8965174e6b7bb48, type: 3}
       propertyPath: m_LocalPosition.x

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scenes/StageScene.unity
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scenes/StageScene.unity
@@ -584,25 +584,9 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 269454219}
     m_Modifications:
-    - target: {fileID: 2859591362753765699, guid: 67f2f256c2e5f46aa8965174e6b7bb48, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -25
-      objectReference: {fileID: 0}
-    - target: {fileID: 3128953194732964171, guid: 67f2f256c2e5f46aa8965174e6b7bb48, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -25
-      objectReference: {fileID: 0}
     - target: {fileID: 3948476144519111223, guid: 67f2f256c2e5f46aa8965174e6b7bb48, type: 3}
       propertyPath: m_Name
       value: MonsterManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 5197511860445037114, guid: 67f2f256c2e5f46aa8965174e6b7bb48, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 25
-      objectReference: {fileID: 0}
-    - target: {fileID: 8365360019841480773, guid: 67f2f256c2e5f46aa8965174e6b7bb48, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 8374344308667646995, guid: 67f2f256c2e5f46aa8965174e6b7bb48, type: 3}
       propertyPath: m_LocalPosition.x
@@ -897,14 +881,6 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6473338925138837413, guid: e7f2d2c4065b5a446a5f11c493e79c23, type: 3}
-      propertyPath: m_FillAmount
-      value: 0.348
-      objectReference: {fileID: 0}
-    - target: {fileID: 6665499900514095090, guid: e7f2d2c4065b5a446a5f11c493e79c23, type: 3}
-      propertyPath: m_Name
-      value: PlayerLevelBox
-      objectReference: {fileID: 0}
     - target: {fileID: 6668412859047440378, guid: e7f2d2c4065b5a446a5f11c493e79c23, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -920,14 +896,6 @@ PrefabInstance:
     - target: {fileID: 6941297726275333298, guid: e7f2d2c4065b5a446a5f11c493e79c23, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6941297726275333298, guid: e7f2d2c4065b5a446a5f11c493e79c23, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6944017857889832122, guid: e7f2d2c4065b5a446a5f11c493e79c23, type: 3}
-      propertyPath: m_IsActive
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6955415310548898081, guid: e7f2d2c4065b5a446a5f11c493e79c23, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1011,14 +979,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8203808812124777269, guid: e7f2d2c4065b5a446a5f11c493e79c23, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9049319340368962746, guid: e7f2d2c4065b5a446a5f11c493e79c23, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9049319340368962746, guid: e7f2d2c4065b5a446a5f11c493e79c23, type: 3}
-      propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -1203,14 +1163,6 @@ PrefabInstance:
     - target: {fileID: 532053979963194707, guid: 1d0f443d025e149e687f1e7e3287efb8, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1786304541592805293, guid: 1d0f443d025e149e687f1e7e3287efb8, type: 3}
-      propertyPath: orthographic size
-      value: 25
-      objectReference: {fileID: 0}
-    - target: {fileID: 3507456370971871786, guid: 1d0f443d025e149e687f1e7e3287efb8, type: 3}
-      propertyPath: m_Lens.OrthographicSize
-      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 5916570982874310088, guid: 1d0f443d025e149e687f1e7e3287efb8, type: 3}
       propertyPath: m_Name

--- a/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/AttackData.asset
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/AttackData.asset
@@ -26,9 +26,9 @@ MonoBehaviour:
   playerScanRange: 10
   droneScanRange: 40
   randomRange: 5
-  basicFireDamage: 2
-  upgradeFireDamage: 3
-  laserDamage: 10
-  bombDamage: 8
-  droneDamage: 3
-  dashDamage: 99
+  basicFireDamage: 15
+  upgradeFireDamage: 30
+  laserDamage: 20
+  bombDamage: 30
+  droneDamage: 10
+  dashDamage: 20

--- a/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/GameManagerData.asset
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/GameManagerData.asset
@@ -13,6 +13,6 @@ MonoBehaviour:
   m_Name: GameManagerData
   m_EditorClassIdentifier: 
   GameReadyTime: 2
-  GameStageTime: 60
+  GameStageTime: 180
   BossReadyTime: 2
   GameEndTimeDelay: 2

--- a/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MagnetData.asset
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MagnetData.asset
@@ -12,5 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bec30db5b2175456d8d0587a1cd83cf8, type: 3}
   m_Name: MagnetData
   m_EditorClassIdentifier: 
-  magnetItemMoveSpeed: 10
-  magnetDistance: 7
+  magnetItemMoveSpeed: 30
+  fasterMagnetItemMoveSpeed: 50
+  magnetDistance: 12

--- a/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterBlastSkillData.asset
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterBlastSkillData.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 78229cb7dd3674d948c9527a7e9ca463, type: 3}
   m_Name: MonsterBlastSkillData
   m_EditorClassIdentifier: 
-  WaveBlastDamage: 10
-  BigWaveDamage: 5
+  WaveBlastDamage: 30
+  BigWaveDamage: 50
   PositionCount: 50
   WaveBlastMaxRadius: 5
   BigWaveMaxRadius: 20

--- a/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterBossAData.asset
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterBossAData.asset
@@ -12,12 +12,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a790b530a65db4cc893c56511f5a39d9, type: 3}
   m_Name: MonsterBossAData
   m_EditorClassIdentifier: 
-  AttackPower: 10
-  HP: 100000
-  Speed: 25
+  AttackPower: 30
+  HP: 3000
+  Speed: 15
   AttackRange: 7
   AttackInterval: 0.5
-  AttackSpeed: 5
+  AttackSpeed: 2
   AttackCount: 4
   ReadyDashTime: 1.5
   DashPoint: 1

--- a/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterBossBData.asset
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterBossBData.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3c314e9b3b52f4f26bf39f2b419440c1, type: 3}
   m_Name: MonsterBossBData
   m_EditorClassIdentifier: 
-  AttackPower: 5
-  HP: 1000
+  AttackPower: 30
+  HP: 50000
   Speed: 15
   AttackRange: 10
   AttackInterval: 0.5
@@ -27,4 +27,4 @@ MonoBehaviour:
   ReadyFatManTime: 2
   FatManRate: 0.5
   FatManCount: 10
-  FatManDamage: 15
+  FatManDamage: 50

--- a/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterEliteLongRange.asset
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterEliteLongRange.asset
@@ -13,10 +13,10 @@ MonoBehaviour:
   m_Name: MonsterEliteLongRange
   m_EditorClassIdentifier: 
   monsterType: 1
-  attackPower: 5
-  hp: 20
+  attackPower: 10
+  hp: 60
   speed: 10
-  attackRange: 10
+  attackRange: 15
   attackInterval: 0.5
   attackSpeed: 2
   exp: 2

--- a/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterEliteShorRange.asset
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterEliteShorRange.asset
@@ -13,8 +13,8 @@ MonoBehaviour:
   m_Name: MonsterEliteShorRange
   m_EditorClassIdentifier: 
   monsterType: 1
-  attackPower: 5
-  hp: 20
+  attackPower: 10
+  hp: 60
   speed: 15
   attackRange: 5
   attackInterval: 0.5

--- a/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterManagerData.asset
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterManagerData.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 962432537541c4282aabe14bc7d9e50c, type: 3}
   m_Name: MonsterManagerData
   m_EditorClassIdentifier: 
-  SpawnInterval: 2
+  SpawnInterval: 1
   TotalSpawnQty: 1
   NormalShortRangeQty: 1
   NormalLongRangeQty: 1

--- a/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterNormalLongRage.asset
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterNormalLongRage.asset
@@ -12,10 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4305be8c4517d4ed3b553ad3866e980e, type: 3}
   m_Name: MonsterNormalLongRage
   m_EditorClassIdentifier: 
-  attackPower: 1
-  hp: 10
-  speed: 3
-  attackRange: 10
+  monsterType: 0
+  attackPower: 10
+  hp: 15
+  speed: 10
+  attackRange: 15
   attackInterval: 0.5
-  attackSpeed: 2
+  attackSpeed: 3
   exp: 1

--- a/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterNormalShortage.asset
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/MonsterNormalShortage.asset
@@ -13,9 +13,9 @@ MonoBehaviour:
   m_Name: MonsterNormalShortage
   m_EditorClassIdentifier: 
   monsterType: 0
-  attackPower: 1
-  hp: 10
-  speed: 15
+  attackPower: 10
+  hp: 15
+  speed: 20
   attackRange: 5
   attackInterval: 0.5
   attackSpeed: 5

--- a/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/PlayerData.asset
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/ScriptableObject/PlayerData.asset
@@ -13,14 +13,14 @@ MonoBehaviour:
   m_Name: PlayerData
   m_EditorClassIdentifier: 
   playerSpeed: 10
-  dashLimitTic1SecondsTo50: 5
+  dashLimitTic1SecondsTo50: 4
   onTheRockQuitTic: 50
-  dashSpeed: 10
+  dashSpeed: 15
   player_Max_HP: 1000
-  hp_Heal_Counter_x50: 50
-  hp_Heal_Amount: 1
+  hp_Heal_Counter_x50: 0
+  hp_Heal_Amount: 0
   level_Up_Require_EXP: 300
   level_Up_EXP: 300
   hitEffectTime: 0.25
   dashRechargeTic: 150
-  maxDashSavings: 99
+  maxDashSavings: 5

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Global/Monster/MonsterNormal.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Global/Monster/MonsterNormal.cs
@@ -207,6 +207,7 @@ public class MonsterNormal : Monster
             ObjectPoolManager.Inst.DestroyObject(boomEffect);
             ObjectPoolManager.Inst.DestroyObject(boomCollider);
             
+            yield return new WaitForSeconds(0.1f);
             ObjectPoolManager.Inst.DestroyObject(this.gameObject);
     }
 

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Global/Monster/MonsterNormal.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Global/Monster/MonsterNormal.cs
@@ -8,7 +8,7 @@ public class MonsterNormal : Monster
     public IObjectPool<GameObject> myPool { get; set; }
 
     [SerializeField] private MonsterData _monsterData;
-
+    
     // nav mesh related variables 
     private NavMeshAgent _navMeshAgent = null;
     private Transform _target = null;
@@ -25,13 +25,17 @@ public class MonsterNormal : Monster
     
     // private variables 
 
+    private Color shortColor = Color.white;
+    [SerializeField] private Color longColor;
+
     private float _attacktime;
     private MonsterAttack _monsterAttack;
     private float _laserHitRate = 0.7f;
     private float _laserHitDelay;
     private bool _isLaserHit;
     private bool _isLaserOn;
-
+    [SerializeField] private bool isShort;
+    
     // Monster state
     public enum state
     {
@@ -57,7 +61,6 @@ public class MonsterNormal : Monster
         if(_currentState == state.attack)
         {
             this.transform.LookAt(_target);
-
         }
     }
 
@@ -80,7 +83,14 @@ public class MonsterNormal : Monster
         monsterHP = _monsterData.hp;
         
         // set material color 
-        _renderers[0].material.color = Color.white;
+        if (isShort)
+        {
+            _renderers[0].material.color = shortColor;
+        }
+        else
+        {
+            _renderers[0].material.color = longColor;
+        }
 
         // set nav mesh agent values 
         _navMeshAgent.stoppingDistance = _monsterData.attackRange;
@@ -236,7 +246,14 @@ public class MonsterNormal : Monster
     {
         _renderers[0].material.color = Color.red;
         yield return new WaitForSeconds(0.25f);
-        _renderers[0].material.color = Color.white;
+        if (isShort)
+        {
+            _renderers[0].material.color = shortColor;
+        }
+        else
+        {
+            _renderers[0].material.color = longColor;
+        }
     }
     
     

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Global/SoundEffectController.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Global/SoundEffectController.cs
@@ -66,7 +66,13 @@ public class SoundEffectController : MonoBehaviour
         {
             return;
         }
-        audioSource.volume = effectVolume * sampleVolumeSettingValue;
+        audioSource.volume = effectVolume;
+        StartCoroutine(playOneSound(effectVolume, _type));
+    }
+
+    private IEnumerator playOneSound(float vol, StageSoundTypes _type)
+    {
+        yield return new WaitForFixedUpdate();
         audioSource.PlayOneShot(StageSoundEffects[(int)_type]);
     }
     

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Space/PlayerStatus.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Space/PlayerStatus.cs
@@ -159,23 +159,23 @@ public class PlayerStatus : MonoBehaviour
         
     }
 
-    private void OnCollisionEnter(Collision other)
+    private void OnControllerColliderHit(ControllerColliderHit hit)
     {
-        if (other.collider.gameObject.CompareTag("Monster"))
+        if (hit.gameObject.CompareTag("Monster"))
         {
-            Debug.Log($"{other.gameObject.name} : 몬스터와 충돌! 10의 데미지를 입었다.");
+            Debug.Log($"{hit.gameObject.name} : 몬스터와 충돌! 10의 데미지를 입었다.");
 
             ApplyDamage(10);
             
             StartCoroutine(PlayerHitEffect());
         }
-        else if (other.collider.gameObject.CompareTag("MonsterAttack"))
+        /*else if (other.collider.gameObject.CompareTag("MonsterAttack"))
         {
             ApplyDamage((int)other.gameObject.GetComponent<MonsterAttack>().Damage);
             //other.gameObject.SetActive(false);
             Debug.Log($"{other.gameObject.name} : 몬스터 공격! {other.gameObject.GetComponent<MonsterAttack>().Damage}");
             StartCoroutine(PlayerHitEffect());
-        }
+        }*/
     }
     
     private void ApplyDamage(int damage)

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Space/PlayerStatus.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Space/PlayerStatus.cs
@@ -192,38 +192,23 @@ public class PlayerStatus : MonoBehaviour
             Debug.Log($"{other.gameObject.name} : 몬스터 공격! {other.gameObject.GetComponent<MonsterAttack>().Damage}");
             StartCoroutine(PlayerHitEffect());
         }
-        
-        if (other.CompareTag("boxCat") || other.CompareTag("EXPBox"))
+        else if (other.CompareTag("boxCat"))
         {
-            if(other.CompareTag("boxCat"))
-            {
-                other.gameObject.SetActive(false);
-                ItemController.Inst.DropItem();
-            }
-            else
-            {
-                ObjectPoolManager.Inst.DestroyObject(other.gameObject);
-                player_now_EXP += 10;
-            }
-            
-            // 플레이어 레벨업 로직을 UI에서 마무리하고 싶다면 주석 처리할 것
-            // if (_playerData.level_Up_Require_EXP - player_now_EXP <= 0)
-            // {
-            //     player_Level += 1;
-            //     player_now_EXP -= _playerData.level_Up_Require_EXP;
-            // }
-            
+            other.gameObject.SetActive(false);
+            ItemController.Inst.DropItem();
             soundEffectController.playStageSoundEffect(0.5f,SoundEffectController.StageSoundTypes.Boxcat_Gold);
         }
-    }
-
-    private void OnControllerColliderHit(ControllerColliderHit hit)
-    {
-        if (hit.gameObject.CompareTag("EXPBox"))
+        else if (other.CompareTag("EXPBox"))
         {
-            ObjectPoolManager.Inst.DestroyObject(hit.gameObject);
+            ObjectPoolManager.Inst.DestroyObject(other.gameObject);
             player_now_EXP += 10;
             soundEffectController.playStageSoundEffect(0.5f,SoundEffectController.StageSoundTypes.Boxcat_Gold);
         }
+        // 플레이어 레벨업 로직을 UI에서 마무리하고 싶다면 주석 처리할 것
+        // if (_playerData.level_Up_Require_EXP - player_now_EXP <= 0)
+        // {
+        //     player_Level += 1;
+        //     player_now_EXP -= _playerData.level_Up_Require_EXP;
+        // }
     }
 }

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/UI/StageUI/StageUIScript.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/UI/StageUI/StageUIScript.cs
@@ -53,7 +53,7 @@ namespace ProjectDaNyan.Views.StageUI
         public HiddenSkillType[] hiddenSkillTypes = { HiddenSkillType.WideAreaAttack, HiddenSkillType.LaserAttack };
         private HiddenSkillType _hiddenSkillType;
         private int _randomNumber; //To Change Hidden Skill Types Randomly at Start Point
-        private float _hiddenSkillRate = 35f;
+        private float _hiddenSkillRate = 1f;
         private float _hiddenSkillDelay = 0;
         //Hidden Skill On/Off Boolean
         private bool _isHiddenReady;

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/UI/StageUI/StageUIScript.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/UI/StageUI/StageUIScript.cs
@@ -53,7 +53,7 @@ namespace ProjectDaNyan.Views.StageUI
         public HiddenSkillType[] hiddenSkillTypes = { HiddenSkillType.WideAreaAttack, HiddenSkillType.LaserAttack };
         private HiddenSkillType _hiddenSkillType;
         private int _randomNumber; //To Change Hidden Skill Types Randomly at Start Point
-        private float _hiddenSkillRate = 1f;
+        private float _hiddenSkillRate = 35f;
         private float _hiddenSkillDelay = 0;
         //Hidden Skill On/Off Boolean
         private bool _isHiddenReady;

--- a/ProjectDaNyan/Assets/Resources/BGM.mp3.meta
+++ b/ProjectDaNyan/Assets/Resources/BGM.mp3.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 1
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -13,7 +13,7 @@ AudioImporter:
     conversionMode: 0
     preloadAudioData: 0
   platformSettingOverrides: {}
-  forceToMono: 0
+  forceToMono: 1
   normalize: 1
   loadInBackground: 0
   ambisonic: 0

--- a/ProjectDaNyan/Assets/Resources/Effect_Stage/Boxcat_Gold.wav.meta
+++ b/ProjectDaNyan/Assets/Resources/Effect_Stage/Boxcat_Gold.wav.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 1
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/ProjectDaNyan/Assets/Resources/Effect_Stage/Monster_Hit.wav.meta
+++ b/ProjectDaNyan/Assets/Resources/Effect_Stage/Monster_Hit.wav.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 1
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -13,7 +13,7 @@ AudioImporter:
     conversionMode: 0
     preloadAudioData: 0
   platformSettingOverrides: {}
-  forceToMono: 0
+  forceToMono: 1
   normalize: 1
   loadInBackground: 0
   ambisonic: 0

--- a/ProjectDaNyan/Assets/Resources/Effect_Stage/Player_Attack.wav.meta
+++ b/ProjectDaNyan/Assets/Resources/Effect_Stage/Player_Attack.wav.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 1
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -13,7 +13,7 @@ AudioImporter:
     conversionMode: 0
     preloadAudioData: 0
   platformSettingOverrides: {}
-  forceToMono: 0
+  forceToMono: 1
   normalize: 1
   loadInBackground: 0
   ambisonic: 0


### PR DESCRIPTION
작업 내역 :
밸런스 패치 반영

원거리 몬스터 텍스쳐가 근거리랑 동일하게 나오는 현상 수정
> 코드상 색상 설정이 잘못되어 있었음

플레이어에게 경험치가 물리적으로 충돌하는 현상
> OnCharacterColliderHit은 알고보니 캐릭터에게 1회 물리적 충돌을 일으킴, 이것때문에 캐릭터가 땅에서 살짝 떴다 내려오는 버그 발생
> 캐릭터에 isTrigger이 켜진 박스 콜라이더 추가하고 OnTriggerEnter에서 경험치 먹게 처리