### PR TITLE
Fix : zombie monster generation

### DIFF
--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/EXPBox.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/EXPBox.prefab
@@ -14,7 +14,6 @@ GameObject:
   - component: {fileID: 847780073295936240}
   - component: {fileID: 7727609116909889756}
   - component: {fileID: 7965975219053388132}
-  - component: {fileID: 5532538831822095849}
   - component: {fileID: 6721862226773484621}
   m_Layer: 0
   m_Name: EXPBox
@@ -133,33 +132,6 @@ NavMeshObstacle:
   m_CarveOnlyStationary: 1
   m_Center: {x: 0, y: 0, z: 0}
   m_TimeToStationary: 0.5
---- !u!54 &5532538831822095849
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7703086083745402384}
-  serializedVersion: 4
-  m_Mass: 10
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
 --- !u!65 &6721862226773484621
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteLongRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteLongRangePrefab.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 1592630744727539676}
   - component: {fileID: 3857333942012257283}
   - component: {fileID: 5472813065106778144}
-  - component: {fileID: 6804289446639036155}
+  - component: {fileID: -292629442279892744}
   m_Layer: 8
   m_Name: MonsterEliteLongRangePrefab
   m_TagString: Monster
@@ -62,6 +62,7 @@ MonoBehaviour:
   _expBox: {fileID: 7703086083745402384, guid: d4e304cf3b1f049619280b63ac734983, type: 3}
   _currentState: 0
   _attackPoint: {fileID: 1022124332221860566}
+  longColor: {r: 0, g: 0, b: 0, a: 0}
   isShort: 0
 --- !u!65 &3857333942012257283
 BoxCollider:
@@ -106,33 +107,22 @@ NavMeshAgent:
   m_BaseOffset: 0.5
   m_WalkableMask: 4294967295
   m_ObstacleAvoidanceType: 2
---- !u!54 &6804289446639036155
-Rigidbody:
+--- !u!208 &-292629442279892744
+NavMeshObstacle:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7512927405108858682}
-  serializedVersion: 4
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 116
-  m_CollisionDetection: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Shape: 1
+  m_Extents: {x: 1.5, y: 1, z: 1}
+  m_MoveThreshold: 0.1
+  m_Carve: 0
+  m_CarveOnlyStationary: 1
+  m_Center: {x: 0, y: 1, z: 0}
+  m_TimeToStationary: 0.5
 --- !u!1001 &6425218464773285886
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteShortRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterEliteShortRangePrefab.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 3814177440157266606}
   - component: {fileID: 8376100200426359010}
   - component: {fileID: 7363999885104610313}
-  - component: {fileID: 6056631384003765915}
+  - component: {fileID: 432924039727506004}
   m_Layer: 8
   m_Name: MonsterEliteShortRangePrefab
   m_TagString: Monster
@@ -62,6 +62,7 @@ MonoBehaviour:
   _expBox: {fileID: 7703086083745402384, guid: d4e304cf3b1f049619280b63ac734983, type: 3}
   _currentState: 0
   _attackPoint: {fileID: 6021140740380600468}
+  longColor: {r: 0, g: 0, b: 0, a: 0}
   isShort: 1
 --- !u!195 &8376100200426359010
 NavMeshAgent:
@@ -106,33 +107,22 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 3.35, y: 11.911131, z: 1.8318763}
   m_Center: {x: 0, y: 5.980566, z: 0}
---- !u!54 &6056631384003765915
-Rigidbody:
+--- !u!208 &432924039727506004
+NavMeshObstacle:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4650249157541409608}
-  serializedVersion: 4
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 116
-  m_CollisionDetection: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Shape: 1
+  m_Extents: {x: 1.5, y: 1, z: 1}
+  m_MoveThreshold: 0.1
+  m_Carve: 0
+  m_CarveOnlyStationary: 1
+  m_Center: {x: 0, y: 1, z: 0}
+  m_TimeToStationary: 0.5
 --- !u!1001 &7743599086039301939
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterLongRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterLongRangePrefab.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 5472813065106778144}
   - component: {fileID: 657133416048315651}
   - component: {fileID: 1790176278812915998}
-  - component: {fileID: 1168645230308861768}
+  - component: {fileID: -3540871985710662710}
   m_Layer: 8
   m_Name: MonsterLongRangePrefab
   m_TagString: Monster
@@ -107,33 +107,22 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1.33, y: 10.306787, z: 1}
   m_Center: {x: 0, y: 4.6533933, z: 0}
---- !u!54 &1168645230308861768
-Rigidbody:
+--- !u!208 &-3540871985710662710
+NavMeshObstacle:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7512927405108858682}
-  serializedVersion: 4
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 116
-  m_CollisionDetection: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Shape: 1
+  m_Extents: {x: 0.5, y: 0.5, z: 0.5}
+  m_MoveThreshold: 0.1
+  m_Carve: 0
+  m_CarveOnlyStationary: 1
+  m_Center: {x: 0, y: 0, z: 0}
+  m_TimeToStationary: 0.5
 --- !u!1001 &1796630008162393520
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterShortRangePrefab.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/MonsterShortRangePrefab.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 2130688296009858312}
   - component: {fileID: 7203151038393716762}
   - component: {fileID: 6483792415486631229}
-  - component: {fileID: 6739086806372851411}
+  - component: {fileID: 2663863524518989190}
   m_Layer: 8
   m_Name: MonsterShortRangePrefab
   m_TagString: Monster
@@ -84,6 +84,7 @@ MonoBehaviour:
   _expBox: {fileID: 7703086083745402384, guid: d4e304cf3b1f049619280b63ac734983, type: 3}
   _currentState: 0
   _attackPoint: {fileID: 7568059509539987083}
+  longColor: {r: 0, g: 0, b: 0, a: 0}
   isShort: 1
 --- !u!65 &6483792415486631229
 BoxCollider:
@@ -106,33 +107,22 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1.33, y: 13.694561, z: 1}
   m_Center: {x: 0, y: 6.3472805, z: 0}
---- !u!54 &6739086806372851411
-Rigidbody:
+--- !u!208 &2663863524518989190
+NavMeshObstacle:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1794225786178493336}
-  serializedVersion: 4
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 116
-  m_CollisionDetection: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Shape: 1
+  m_Extents: {x: 0.5, y: 0.5, z: 0.5}
+  m_MoveThreshold: 0.1
+  m_Carve: 0
+  m_CarveOnlyStationary: 1
+  m_Center: {x: 0, y: 0, z: 0}
+  m_TimeToStationary: 0.5
 --- !u!1001 &7974819580680501083
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Global/Monster/MonsterNormal.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Global/Monster/MonsterNormal.cs
@@ -71,8 +71,16 @@ public class MonsterNormal : Monster
 
     private void OnEnable()
     {
+        resetMonster();
+    }
+
+
+    private void resetMonster()
+    {
+        // if monster is not on the nav mesh, destroy
         if(!_navMeshAgent.isOnNavMesh)
         {
+            ObjectPoolManager.Inst.DestroyObject(this.gameObject);
             return;
         }
         
@@ -106,12 +114,17 @@ public class MonsterNormal : Monster
         _playerAttack = GameObject.Find("PlayerAttackPosition").GetComponent<PlayerAttack>();
 
         if (this.gameObject.transform.Find("BombOnMonster") != null &&
-                        this.gameObject.transform.Find("BombOnMonster").gameObject.activeSelf == true)
+            this.gameObject.transform.Find("BombOnMonster").gameObject.activeSelf == true)
         {
             this.gameObject.transform.Find("BombOnMonster").gameObject.SetActive(false);
         }
     }
-
+    
+    
+    
+    
+    
+    
     IEnumerator monsterState()
     {
 
@@ -124,6 +137,7 @@ public class MonsterNormal : Monster
             yield return StartCoroutine(_currentState.ToString());
         }
 
+        _currentState = state.dead;
         StartCoroutine(dead());
     }
 
@@ -169,8 +183,7 @@ public class MonsterNormal : Monster
 
         // drop exp 
         expBoxData.exp = _monsterData.exp;
-        expBoxData.parentsVelocity = _navMeshAgent.velocity;
-        expBox.transform.position = this.transform.position + Vector3.up * 4f;
+        expBox.transform.position = this.transform.position + Vector3.up * 2f;
 
         //몬스터가 죽을 시 폭탄 터짐
         if (this.gameObject.transform.Find("BombOnMonster") != null)
@@ -221,7 +234,7 @@ public class MonsterNormal : Monster
             transform.position = _target.position + _target.forward * 30f; 
         }
 
-        else if (_navMeshAgent.remainingDistance <= _monsterData.attackRange && distance <= _monsterData.attackRange)
+        else if (distance <= _monsterData.attackRange || _navMeshAgent.remainingDistance <= _monsterData.attackRange)
         {
             _navMeshAgent.isStopped = true;
             _currentState = state.attack;

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Space/EXPBox.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Space/EXPBox.cs
@@ -5,43 +5,7 @@ using UnityEngine.Pool;
 public class EXPBox : MonoBehaviour
 {
     public IObjectPool<GameObject> myPool { get; set; }
-    
-    [SerializeField] private float popForce = 20f;
 
     // depends on monster's exp value 
     public float exp;
-
-    public Vector3 parentsVelocity;
-
-    Rigidbody _rigidbody = null;
-    
-    private void Awake()
-    {
-        _rigidbody = GetComponent<Rigidbody>();
-    }
-
-    private void OnEnable()
-    {
-        _rigidbody.constraints = RigidbodyConstraints.None;
-        _rigidbody.AddForce(parentsVelocity * popForce, ForceMode.Impulse);
-        _rigidbody.AddForce(Vector3.up * popForce, ForceMode.Impulse);
-    }
-
-    private void OnTriggerEnter(Collider other)
-    {
-        if (other.gameObject.layer == LayerMask.NameToLayer("Map_Floor"))
-        {
-            _rigidbody.velocity = Vector3.zero;
-        }
-    }
-    
-    
-    private void OnTriggerExit(Collider other)
-    {
-        if (other.gameObject.layer == LayerMask.NameToLayer("Map_Floor"))
-        {
-            _rigidbody.constraints = RigidbodyConstraints.FreezeAll;
-            _rigidbody.velocity = Vector3.zero;
-        }
-    }
 }


### PR DESCRIPTION
- 좀비 몬스터 에러 수정 (루빅 테스트 필요)
- EXP Box rigidbody 제거 박스가 튀는 효과가 다른 피격 효과에 보이지 않아 필요 없어서 삭제 합니다.
- Monster Prefab에 rigidbody 제거 후 nav mesh obstacle 추가 루빅 테스트 후 이상 있으면 rigidbody 추가 필요합니다.
#183 