### PR TITLE
Improve: 사운드 딜레이 없앰, 플레이어 살짝 공중부양, 몬스터 충돌 데미지 조절 용이하게 변경

### DIFF
--- a/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/Player.prefab
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Player_characrer_monster/Player.prefab
@@ -175,13 +175,13 @@ CharacterController:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Height: 5
-  m_Radius: 1
+  m_Height: 3
+  m_Radius: 0.85
   m_SlopeLimit: 45
   m_StepOffset: 0.3
   m_SkinWidth: 0.08
   m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 1, z: -0.17}
+  m_Center: {x: 0, y: 1.39, z: -0.17}
 --- !u!114 &6667353087869614381
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -562,8 +562,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1.8236238, y: 3.085046, z: 1.4040611}
-  m_Center: {x: -0.03133732, y: 1.4167839, z: -0.09112215}
+  m_Size: {x: 1.8236238, y: 2.9049413, z: 1.0014956}
+  m_Center: {x: -0.03133732, y: 1.5068363, z: -0.07390165}
 --- !u!1001 &1289221656642250242
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Global/PlayerData.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Global/PlayerData.cs
@@ -20,6 +20,7 @@ public class PlayerData: ScriptableObject
     [SerializeField] public int level_Up_Require_EXP = 100;
     [SerializeField] public int level_Up_EXP = 100;
     [SerializeField] public float hitEffectTime = .25f;
+    [SerializeField] public int playerAttackedByMobDamage = 10;
     
     // ======= JoystickController 에서 사용될 데이터
     [SerializeField] public int dashRechargeTic = 150;

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Global/SoundEffectController.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Global/SoundEffectController.cs
@@ -72,8 +72,9 @@ public class SoundEffectController : MonoBehaviour
 
     private IEnumerator playOneSound(float vol, StageSoundTypes _type)
     {
-        yield return new WaitForFixedUpdate();
+        //yield return new WaitForFixedUpdate(); 사운드 딜레이 잠깐 주석처리 (이방법으로 소리크기 여러군데서 수정 시 왔다갔다 하는거 해결안됨)
         audioSource.PlayOneShot(StageSoundEffects[(int)_type]);
+        yield return null;
     }
     
     public void playShelterUISoundEffects(float effectVolume, ShelterUISoundTypes _type)

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Space/PlayerController.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Space/PlayerController.cs
@@ -43,7 +43,7 @@ public class PlayerController : MonoBehaviour
     private float jumpForce = 300;
     private float timeBeforeNextJump = 1.2f;
     private float canJump = 0f;
-    private float rockHeight = 5.85f;
+    private float rockHeight = 5.55f;
 
     private float playerRotationPositionX;
     private float playerRotationPositionY;
@@ -202,10 +202,7 @@ public class PlayerController : MonoBehaviour
     {
         if (playerCharacterController.isGrounded == false)
         {
-            if (this.transform.position.y > 0f)
-            { 
                 _floatingPosition += -9.81f * Time.deltaTime; 
-            }
         }
         else
         {
@@ -247,7 +244,8 @@ public class PlayerController : MonoBehaviour
     void PlayerExitStartFromRock()
     {
         StartCoroutine(PlayerDashSetting());
-        transform.position = new Vector3(transform.position.x, y:1.3f, transform.position.z);
+        transform.position = new Vector3(transform.position.x + dashMovePosition.x, y:1.3f, transform.position.z + dashMovePosition.z);
+        dashTimerCount = 1;
         _playerState.setPsData(PlayerState.PSData.exitDashFromRock);
     }
     

--- a/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Space/PlayerStatus.cs
+++ b/ProjectDaNyan/Assets/ProjectDaNyan/Scripts/Space/PlayerStatus.cs
@@ -165,7 +165,7 @@ public class PlayerStatus : MonoBehaviour
         {
             Debug.Log($"{hit.gameObject.name} : 몬스터와 충돌! 10의 데미지를 입었다.");
 
-            ApplyDamage(10);
+            ApplyDamage(_playerData.playerAttackedByMobDamage);
             
             StartCoroutine(PlayerHitEffect());
         }


### PR DESCRIPTION
작업내역:

1. 사운드 딜레이 제거 (fixedupdate 한틱 기다리게 하는 코드 주석처리)
2. 플레이어 살짝 공중부양해서 몬스터 밟고 올라가는 문제 수정 (floatingPosition쪽 코드가 문제)
3. 몬스터 충돌 시 플레이어가 입는 데미지 조절칸을 PlayerData에 추가